### PR TITLE
improvements for detecting over large arrays with memory constraints

### DIFF
--- a/src/yews/cpic/detection.py
+++ b/src/yews/cpic/detection.py
@@ -4,6 +4,7 @@ from scipy.special import expit
 
 from .utils import compute_probs
 from .utils import sliding_window_view
+from .utils import chunks
 
 def find_nonzero_runs(a):
     # source: https://stackoverflow.com/
@@ -18,11 +19,30 @@ def find_nonzero_runs(a):
 
 
 def detect(waveform, fs, wl, model, transform, g, threshold=0.5,
-           batch_size=None):
-    probs = compute_probs(model, transform, waveform,
-                          shape=[3, fs * wl],
-                          step=[1, int(g * fs)],
-                          batch_size=batch_size)
+           batch_size=None, size_limit=None):
+    """size_limit is the maximum number of waveform array elements in the
+    long dimension to be processed at a time. Can be used when working with
+    memory constraints. Should be an integer multiple of fs*wl"""
+    if size_limit:
+        if not (isinstance(size_limit, int)):
+            raise TypeError("size_limit must be type integer") 
+        if size_limit % (fs*wl) != 0:
+            raise ValueError("size_limit must be integer multiple of fs*wl")
+        probs_list = []
+        offset = int(fs*(wl - g))
+        for chunk in chunks(waveform, size_limit, offset):
+            probs = compute_probs(model, transform, chunk,
+                                  shape=[3, fs * wl],
+                                  step=[1, int(g * fs)],
+                                  batch_size=batch_size)
+            probs_list.append(probs)
+        probs = np.concatenate(probs_list, axis=1)
+        
+    else:
+        probs = compute_probs(model, transform, waveform,
+                              shape=[3, fs * wl],
+                              step=[1, int(g * fs)],
+                              batch_size=batch_size)
 
     probs[probs < threshold] = 0
     p_prob, s_prob = probs[1:]

--- a/src/yews/cpic/detection.py
+++ b/src/yews/cpic/detection.py
@@ -25,7 +25,7 @@ def detect(waveform, fs, wl, model, transform, g, threshold=0.5,
     memory constraints. Should be an integer multiple of fs*wl"""
     if size_limit:
         if not (isinstance(size_limit, int)):
-            raise TypeError("size_limit must be type integer") 
+            raise TypeError("size_limit must be type integer")
         if size_limit % (fs*wl) != 0:
             raise ValueError("size_limit must be integer multiple of fs*wl")
         probs_list = []
@@ -37,7 +37,7 @@ def detect(waveform, fs, wl, model, transform, g, threshold=0.5,
                                   batch_size=batch_size)
             probs_list.append(probs)
         probs = np.concatenate(probs_list, axis=1)
-        
+
     else:
         probs = compute_probs(model, transform, waveform,
                               shape=[3, fs * wl],

--- a/src/yews/cpic/utils.py
+++ b/src/yews/cpic/utils.py
@@ -12,7 +12,7 @@ def probs2cfs(probs, sigma=3):
     cf_s = gaussian_filter1d(cf_s, sigma=sigma)
 
     return cf_p, cf_s
-        
+
 def chunks(array, size, offset=0):
     """Yield successive n-sized chunks from array, starting at an offset before
     the end of the previous chunk."""

--- a/src/yews/cpic/utils.py
+++ b/src/yews/cpic/utils.py
@@ -12,11 +12,17 @@ def probs2cfs(probs, sigma=3):
     cf_s = gaussian_filter1d(cf_s, sigma=sigma)
 
     return cf_p, cf_s
-
-def chunks(l, n):
-    """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i:i + n]
+        
+def chunks(array, size, offset=0):
+    """Yield successive n-sized chunks from array, starting at an offset before
+    the end of the previous chunk."""
+    if not (isinstance(size, int) and isinstance(offset, int)):
+        raise TypeError("Arguments 'size' and 'offset' must be type integer")
+    slice_axis = array.ndim - 1
+    axis_length = array.shape[slice_axis]
+    for i in range(0, axis_length - offset, size - offset):
+        range_end = min(i + size, axis_length)
+        yield array.take(indices=range(i, range_end), axis=slice_axis)
 
 def compute_probs(model, transform, waveform, shape, step, batch_size=None):
     model.eval()


### PR DESCRIPTION
chunks function now allows an optional argument offset which staggers the chunks to begin before the end of the previous chunk. This will allow chunking the array passed to detect function without altering the sliding window behaviour. Also changed the chunks function to slice over the last dimension of the input array. For 1D arrays, it works the same, but it now accepts 2D arrays and slices over the last dimension.

detect function in utils/detection.py now takes an optional argument size_limit. If specified, detect uses the chunk function to chunk the waveform array into chunks of size size_limit, computes probabilities for each chunk, appends to a list, and concatenates them all at the end. Output is the exact same as before regardless of whether size_limit is specified or not but should avoid having to compute the transforms (including to_tensor) on very large numpy arrays.