### PR TITLE
Change travis-ci.com to travis-ci.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,8 @@ applying deep learning techniques on seismic waveform data.
 
 
 
-
-.. image:: https://travis-ci.com/lijunzh/yews.svg?branch=master
-    :target: https://travis-ci.com/lijunzh/yews
+.. image:: https://travis-ci.org/yewsg/yews.svg?branch=master
+    :target: https://travis-ci.org/yewsg/yews
 
 .. image:: https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true
     :target: https://ci.appveyor.com/project/lijunzh/yews


### PR DESCRIPTION
Fix #10 

Since lijun's education discount expires, we can no longer use travis-ci.com for CI purposes. There is virtually no difference between travis-ci.org and travis-ci.com for public repositories. Thus, I switched all travis-ci related settings to travis-ci.org.